### PR TITLE
Moving abstain detection to a separate module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This command does the following.
 
 ## Running FActScore using a command line
 
-We expect running FActScore costs about $1 of the API cost per 100 sentences. For instance, if you have 100 generations, each with 5 sentences on average, it costs $5 in total. 
+We expect running FActScore costs about $1 of the API cost per 100 sentences. For instance, if you have 100 generations, each with 5 sentences on average, it costs $5 in total.
 
 ```bash
 python -m factscore.factscorer --input_path {input_path} --model_name {estimator_name} --openai_key {openai_key}
@@ -72,7 +72,7 @@ python -m factscore.factscorer --input_path {input_path} --model_name {estimator
 - `--verbose`: If specified, it shows the progress bar.
 - `--print_rate_limit_error`: It specified, it prints out rate limit errors from OpenAI API.
 - `--cost_estimate`: This flag decides the type of OpenAI API cost estimation that we provide before calling it. It can be `"consider_cache"` (default) or `"ignore_cache"`.
-- `--abstain_detection`: This flag optionally enables automatic detection of abstained responses. By default this is disabled, but it is recommended to add your own function tailored to your model. The currently supported detectors are `"generic"` and `"perplexity_ai"`, and their implementations can be found in [`factscore/abstain_detection.py`](factscore/abstain_detection.py).
+- `--abstain_detection`: This flag optionally enables automatic detection of abstained responses. By default this is disabled, but it is recommended to add your own function tailored to your model. The currently supported detectors are `"generic"` and `"perplexity_ai"`, and their implementations can be found in [`factscore/abstain_detection.py`](factscore/abstain_detection.py). There are two methods to add your own abstain function: a) clone our GitHub repository to install `factscore` locally (`pip install --editable .`), and then add your function to [`factscore/abstain_detection.py`](factscore/abstain_detection.py) directly; b) process your abstain detection outside our package, and use empty strings in the `output` key for the JSONL file used in `--input_path`.
 
 This command uses the English Wikipedia from 2023/04/01 as a knowledge source. See [this section](#To-use-a-custom-knowledge-source) to use your own database as a knowledge source!
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ python -m factscore.factscorer --input_path {input_path} --model_name {estimator
 - `--verbose`: If specified, it shows the progress bar.
 - `--print_rate_limit_error`: It specified, it prints out rate limit errors from OpenAI API.
 - `--cost_estimate`: This flag decides the type of OpenAI API cost estimation that we provide before calling it. It can be `"consider_cache"` (default) or `"ignore_cache"`.
+- `--abstain_detection`: This flag optionally enables automatic detection of abstained responses. By default this is disabled, but it is recommended to add your own function tailored to your model. The currently supported detectors are `"generic"` and `"perplexity_ai"`, and their implementations can be found in [`factscore/abstain_detection.py`](factscore/abstain_detection.py).
 
 This command uses the English Wikipedia from 2023/04/01 as a knowledge source. See [this section](#To-use-a-custom-knowledge-source) to use your own database as a knowledge source!
 

--- a/factscore/abstain_detection.py
+++ b/factscore/abstain_detection.py
@@ -1,0 +1,58 @@
+import numpy as np
+import re
+
+invalid_ppl_mentions = [
+    "I could not find any information",
+    "The search results do not provide",
+    "There is no information",
+    "There are no search results",
+    "there are no provided search results",
+    "not provided in the search results",
+    "is not mentioned in the provided search results",
+    "There seems to be a mistake in the question",
+    "Not sources found",
+    "No sources found",
+    "Try a more general question"
+]
+
+def remove_citation(text):
+    # text = re.sub(r'\[\d+\]', '', text)
+    text = re.sub(r"\s*\[\d+\]\s*","", text)
+    if text.startswith("According to , "):
+        text = text.replace("According to , ", "According to the search results, ")
+    return text
+
+def is_invalid_ppl(text):
+    return np.any([text.lower().startswith(mention.lower()) for mention in invalid_ppl_mentions])
+
+def is_invalid_paragraph_ppl(text):
+    return len(text.strip())==0 or np.any([mention.lower() in text.lower() for mention in invalid_ppl_mentions])
+
+def perplexity_ai_abstain_detect(generation):
+    output = remove_citation(generation)
+    if is_invalid_ppl(output):
+        return True
+    valid_paras = []
+    for para in output.split("\n\n"):
+        if is_invalid_paragraph_ppl(para):
+            break
+        valid_paras.append(para.strip())
+
+    if len(valid_paras) == 0:
+        return True
+    else:
+        return False
+
+def generic_abstain_detect(generation):
+    return generation.startswith("I'm sorry") or "provide more" in generation
+
+def is_response_abstained(generation, fn_type):
+    if fn_type == "perplexity_ai":
+        return perplexity_ai_abstain_detect(generation)
+
+    elif fn_type == "generic":
+        return generic_abstain_detect(generation)
+
+    else:
+        return False
+


### PR DESCRIPTION
Fixes #19 

Before:

```
(dipper-venv) kalpesh@arkham:FActScore$ python factscore/factscorer.py --input_path data/labeled/ChatGPT.jsonl --n_samples 30 
[nltk_data] Downloading package punkt to /home/kalpesh/nltk_data...
[nltk_data]   Package punkt is already up-to-date!
06/25/2023 12:22:21 - root - Estimated OpenAI API cost for atomic fact generation ($0.020 per 1000 tokens): $0.00 for 0 words and 0 tokens
06/25/2023 12:22:25 - root - Estimated OpenAI API cost for factscore evaluation ($0.002 per 1000 tokens): $0.00 for 0 words and 0 tokens
06/25/2023 12:22:25 - root - FActScore = 41.6%
06/25/2023 12:22:25 - root - Respond ratio = 100.0%
06/25/2023 12:22:25 - root - # Atomic facts per valid response = 19.8
(dipper-venv) kalpesh@arkham:FActScore$
```

After:

```
(dipper-venv) kalpesh@arkham:FActScore$ python factscore/factscorer.py --input_path data/labeled/ChatGPT.jsonl --n_samples 30 --abstain_detection generic
[nltk_data] Downloading package punkt to /home/kalpesh/nltk_data...
[nltk_data]   Package punkt is already up-to-date!
06/25/2023 12:21:50 - root - Estimated OpenAI API cost for atomic fact generation ($0.020 per 1000 tokens): $0.00 for 0 words and 0 tokens
06/25/2023 12:21:53 - root - Estimated OpenAI API cost for factscore evaluation ($0.002 per 1000 tokens): $0.00 for 0 words and 0 tokens
06/25/2023 12:21:53 - root - FActScore = 38.6%
06/25/2023 12:21:53 - root - Respond ratio = 56.7%
06/25/2023 12:21:53 - root - # Atomic facts per valid response = 29.9
(dipper-venv) kalpesh@arkham:FActScore$
```