### PR TITLE
#38 Groundwork for migration to new openai >=v1.0.0 python API

### DIFF
--- a/factscore/atomic_facts.py
+++ b/factscore/atomic_facts.py
@@ -6,7 +6,6 @@ import string
 import spacy
 import sys
 import nltk
-import openai
 from rank_bm25 import BM25Okapi
 import os
 import time

--- a/factscore/openai_lm.py
+++ b/factscore/openai_lm.py
@@ -1,16 +1,18 @@
 from factscore.lm import LM
-import openai
+from openai import OpenAI, BadRequestError
 import sys
 import time
 import os
 import numpy as np
 import logging
 
+
 class OpenAIModel(LM):
 
     def __init__(self, model_name, cache_file=None, key_path="api.key"):
         self.model_name = model_name
         self.key_path = key_path
+        self.client = None  # Initialized with load_model() method
         self.temp = 0.7
         self.save_interval = 100
         super().__init__(cache_file)
@@ -21,7 +23,7 @@ class OpenAIModel(LM):
         assert os.path.exists(key_path), f"Please place your OpenAI APT Key in {key_path}."
         with open(key_path, 'r') as f:
             api_key = f.readline()
-        openai.api_key = api_key.strip()
+        self.client = OpenAI(api_key=api_key.strip())
         self.model = self.model_name
 
     def _generate(self, prompt, max_sequence_length=2048, max_output_length=128):
@@ -33,65 +35,71 @@ class OpenAIModel(LM):
             # Construct the prompt send to ChatGPT
             message = [{"role": "user", "content": prompt}]
             # Call API
-            response = call_ChatGPT(message, temp=self.temp, max_len=max_sequence_length)
+            response = call_ChatGPT(message, self.client, temp=self.temp, max_len=max_sequence_length)
             # Get the output from the response
             output = response["choices"][0]["message"]["content"]
             return output, response
         elif self.model_name == "InstructGPT":
             # Call API
-            response = call_GPT3(prompt, temp=self.temp)
+            response = call_GPT3(prompt, self.client, temp=self.temp)
             # Get the output from the response
-            output = response["choices"][0]["text"]
+            output = response.choices[0].message.content
             return output, response
         else:
             raise NotImplementedError()
 
-def call_ChatGPT(message, model_name="gpt-3.5-turbo", max_len=1024, temp=0.7, verbose=False):
+
+def call_ChatGPT(message, openai_client, model_name="gpt-3.5-turbo", max_len=1024, temp=0.7, verbose=False):
     # call GPT-3 API until result is provided and then return it
     response = None
     received = False
     num_rate_errors = 0
     while not received:
         try:
-            response = openai.ChatCompletion.create(model=model_name,
-                                                    messages=message,
-                                                    max_tokens=max_len,
-                                                    temperature=temp)
+            response = openai_client.chat.completions.create(
+                model=model_name,
+                messages=message,
+                max_tokens=max_len,
+                temperature=temp)
             received = True
         except:
             # print(message)
             num_rate_errors += 1
             error = sys.exc_info()[0]
-            if error == openai.error.InvalidRequestError:
+            if error == BadRequestError:
                 # something is wrong: e.g. prompt too long
-                logging.critical(f"InvalidRequestError\nPrompt passed in:\n\n{message}\n\n")
+                logging.critical(f"BadRequestError\nPrompt passed in:\n\n{message}\n\n")
                 assert False
-            
+
             logging.error("API error: %s (%d). Waiting %dsec" % (error, num_rate_errors, np.power(2, num_rate_errors)))
             time.sleep(np.power(2, num_rate_errors))
     return response
 
 
-def call_GPT3(prompt, model_name="text-davinci-003", max_len=512, temp=0.7, num_log_probs=0, echo=False, verbose=False):
+def call_GPT3(prompt, openai_client, model_name="gpt-3.5-turbo-0125", max_len=512, temp=0.7, num_log_probs=0):
     # call GPT-3 API until result is provided and then return it
     response = None
     received = False
     num_rate_errors = 0
     while not received:
         try:
-            response = openai.Completion.create(model=model_name,
-                                                prompt=prompt,
-                                                max_tokens=max_len,
-                                                temperature=temp,
-                                                logprobs=num_log_probs,
-                                                echo=echo)
+            response = openai_client.chat.completions.create(
+                model=model_name,
+                messages=[
+                    {"role": "user", "content": prompt},
+                ],
+                max_tokens=max_len,
+                temperature=temp,
+                logprobs=num_log_probs > 0,  # Needs to be True if num_log_probs > 0
+                top_logprobs=num_log_probs,
+            )
             received = True
         except:
             error = sys.exc_info()[0]
             num_rate_errors += 1
-            if error == openai.error.InvalidRequestError:
+            if error == BadRequestError:
                 # something is wrong: e.g. prompt too long
-                logging.critical(f"InvalidRequestError\nPrompt passed in:\n\n{prompt}\n\n")
+                logging.critical(f"BadRequestError\nPrompt passed in:\n\n{prompt}\n\n")
                 assert False
             logging.error("API error: %s (%d)" % (error, num_rate_errors))
             time.sleep(np.power(2, num_rate_errors))

--- a/preprocessing/preprocess_acl.py
+++ b/preprocessing/preprocess_acl.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import tqdm
 import json
-import openai
+from openai import OpenAI
 from factscore.openai_lm import call_ChatGPT
 from factscore.factscorer import FactScorer
 
@@ -49,12 +49,12 @@ for title in prompt_titles:
 
 with open("api.key", 'r') as f:
     api_key = f.readline()
-openai.api_key = api_key.strip()
+openai_client = OpenAI(api_key=api_key.strip())
 
 responses = []
 for ptitle, prompt in tqdm.tqdm(zip(prompt_titles, prompts_list)):
     message = [{"role": "user", "content": prompt}]
-    response = call_ChatGPT(message, model_name="gpt-3.5-turbo-0301")
+    response = call_ChatGPT(message, openai_client, model_name="gpt-3.5-turbo-0301")
     responses.append({
         "topic": ptitle,
         "output": response["choices"][0]["message"]["content"]


### PR DESCRIPTION
Hi @martiansideofthemoon (tagged you, since you were recently active on #38) 

I have tried to make the necessary changes for the new OpenAI python library to be used with this codebase. I have tested the atomic_facts generator and it seems to work quite well. However, I am not very well-versed in this project, so please do some testing of your own, before considering to merge this. 

Please feel free to change anything according to your needs or give feedback if you'd like me to change something. This project looks very promising and I would like to test our own solutions against this. You have done great work here and I'd be glad to hear back from you!  

## Changelog
 - Removed unused openai import from atomic_facts.py
 - OpenAIModel class now has an internal client attribute which holds an instance of the OpenAI() class
 - The call_ChatGPT and call_GPT3 functions now both use the openAI client with chat. completions
 - The InvalidRequestError has been renamed to BadRequestError, this had to be changed in the codebase as well