### PR TITLE
loosen overly restrictive dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,17 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.7.1"
-torch = "^1.13.0"
+torch = ">=1.13.0 <3.0"
 sentence-transformers = "^2.2.2"
 transformers = "^4.29.2"
 openai = "^0.27.7"
 rank-bm25 = "^0.2.2"
 spacy = "^3.5.3"
-pysqlite-binary = "^0.5.0"
 nltk = "^3.8.1"
+pysqlite-binary = { version = "^0.5.0", optional = true }
+
+[tool.poetry.extras]
+pysqlite-binary = ["pysqlite-binary"]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
@martiansideofthemoon here are the dependency changes i mentioned to the pyproject.toml. It might be possible to further loosen the requirements, tough supporting `torch>2.0` and getting rid of the mandatory install of `pysqlite-binary` was enough for my workflow. Since python already comes with a [sqlite3](https://docs.python.org/3/library/sqlite3.html) module, there's no need to enforce the use of `pysqlite-binary` (which as I mentioned in Slack just failed to install for me due to a missing wheel on my platform). If someone does want it installed, they can do so with `pip install factscore[pysqlite-binary]`